### PR TITLE
Update Deprecated Pandas Function Call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,11 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# emacs
+*~
+*.org
+\#*#
+
+# Jupyter NB Checkpoints
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ bash batch/job_template.sh 	# batch run
 
 CPLEX is cross-platform optimization tool solver a Python API. It is free for students and faculty members at accredited institutions. To download CPLEX:
 
-1. Register for [IBM OnTheHub](https://ibm.onthehub.com/WebStore/Account/VerifyEmailDomain.aspx)
-2. Download the *IBM ILOG CPLEX Optimization Studio* from the [software catalog](https://ibm.onthehub.com/WebStore/ProductSearchOfferingList.aspx?srch=CPLEX)
+1. Register for [IBM OnTheHub](https://ur.us-south.cf.appdomain.cloud/a2mt/email-auth)
+2. Download the *IBM ILOG CPLEX Optimization Studio* from the [software catalog](https://www-03.ibm.com/isc/esd/dswdown/searchPartNumber.wss?partNumber=CJ6BPML)
 3. Install CPLEX Optimization Studio.
 4. Setup the CPLEX Python API [as described here](https://www.ibm.com/support/knowledgecenter/SSSA5P_12.8.0/ilog.odms.cplex.help/CPLEX/GettingStarted/topics/set_up/Python_setup.html).
 

--- a/riskslim/helper_functions.py
+++ b/riskslim/helper_functions.py
@@ -212,7 +212,7 @@ def load_data_from_csv(dataset_csv_file, sample_weights_csv_file = None, fold_cs
     else:
         raise IOError('could not find dataset_csv_file: %s' % dataset_csv_file)
 
-    raw_data = df.as_matrix()
+    raw_data = df.to_numpy()
     data_headers = list(df.columns.values)
     N = raw_data.shape[0]
 
@@ -236,7 +236,7 @@ def load_data_from_csv(dataset_csv_file, sample_weights_csv_file = None, fold_cs
     else:
         if os.path.isfile(sample_weights_csv_file):
             sample_weights = pd.read_csv(sample_weights_csv_file, sep=',', header=None)
-            sample_weights = sample_weights.as_matrix()
+            sample_weights = sample_weights.to_numpy()
         else:
             raise IOError('could not find sample_weights_csv_file: %s' % sample_weights_csv_file)
 


### PR DESCRIPTION
Pandas.DataFrame.as_matrix is deprecated since version 0.23.0 (see docs
and PR 18458). According to the documentation for Pandas 0.25.1, the
recommended function is DataFrame.to_numpy() in place of DataFrame.values
or DataFrame.as_matrix().

https://github.com/pandas-dev/pandas/pull/18458
https://pandas.pydata.org/pandas-docs/version/0.23/generated/pandas.DataFrame.as_matrix.html
https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.values.html